### PR TITLE
Shaun patch location store

### DIFF
--- a/src/components/WidgetGrid/index.tsx
+++ b/src/components/WidgetGrid/index.tsx
@@ -55,7 +55,7 @@ function WidgetGrid({realtimeData}: Props) {
         <Col gx={GUTTER}>
           <SimpleMetric
             title={'Speed '}
-            data={realtimeData.speed}
+            data={parseFloat(realtimeData.speed.toFixed(2))}
             icon={'speedometer'}
           />
         </Col>
@@ -71,7 +71,7 @@ function WidgetGrid({realtimeData}: Props) {
         <Col gx={GUTTER}>
           <SimpleMetric
             title={'Elevation '}
-            data={realtimeData.instantPower}
+            data={parseFloat(realtimeData.altitude.toFixed(2))}
             icon={'image-filter-hdr'}
           />
         </Col>

--- a/src/lib/realtimeData.ts
+++ b/src/lib/realtimeData.ts
@@ -29,7 +29,7 @@ export async function updateRealTimeRecord(record: RealtimeDataModel) {
   return db.write(async () => {
     return record.update(() => {
       record.instantPower = randomInt();
-      record.speed = randomInt();
+      // record.speed = randomInt();
       record.heartRate = randomInt();
       record.cadence = randomInt();
       record.distance = randomInt();


### PR DESCRIPTION
Just a few small changes I noticed when running the location-store PR.
1.) the speed was getting overwritten in realtime due to it still being randomised every 3 seconds
2.) elevation widget was showing data for instantaneous power, so switched it to show altitude now
3.) both speed and altitude were overflowing the widgets, so have rounded them to 2 decimals at the widget.