### PR TITLE
Accumulate and display distance as we move

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -25,11 +25,11 @@ it('App registers location service and logs to db with distance calculated', asy
     mocked: true,
     coords: {
       accuracy: 110,
-      latitude: 10.5,
-      longitude: 150.1,
+      latitude: 41.4027,
+      longitude: 2.1743,
       heading: 10,
       speed: 5,
-      altitude: 200,
+      altitude: 41.0,
       altitudeAccuracy: 0,
     },
   };
@@ -51,11 +51,11 @@ it('App registers location service and logs to db with distance calculated', asy
     mocked: true,
     coords: {
       accuracy: 110,
-      latitude: 22.5,
-      longitude: 15.1,
+      latitude: 41.4035,
+      longitude: 2.1732,
       heading: 10,
       speed: 5,
-      altitude: 400,
+      altitude: 49.0,
       altitudeAccuracy: 0,
     },
   };
@@ -67,10 +67,10 @@ it('App registers location service and logs to db with distance calculated', asy
     Location._emitLocation(nextLocation);
   });
 
-  // change me.
-  expect(record.distance).toBe(300);
-  expect(record.latitude).toBe(nextLocation.coords.latitude);
-  expect(record.longitude).toBe(nextLocation.coords.longitude);
+  let updatedRecord = await getOrCreateRealtimeRecord();
+  expect(updatedRecord.distance).toBeCloseTo(128.0, 0);
+  expect(updatedRecord.latitude).toBe(nextLocation.coords.latitude);
+  expect(updatedRecord.longitude).toBe(nextLocation.coords.longitude);
 
   // Now check for record in realtime db.
   tree.unmount();

--- a/App.test.tsx
+++ b/App.test.tsx
@@ -14,15 +14,14 @@ it('App renders correctly for signed user.', async () => {
   tree.unmount();
 });
 
-it('App registers location service and logs to db', async () => {
-  // check the home pages renders
+it('App registers location service and logs to db with distance calculated', async () => {
   let tree!: ReactTestRenderer;
   await renderer.act(() => {
     tree = renderer.create(<App />);
   });
   tree.root.findByType(Home);
   const newLocation = {
-    timestamp: new Date().getUTCMinutes(),
+    timestamp: new Date().getUTCMilliseconds(),
     mocked: true,
     coords: {
       accuracy: 110,
@@ -43,9 +42,35 @@ it('App registers location service and logs to db', async () => {
   });
 
   let record = await getOrCreateRealtimeRecord();
-
+  expect(record.distance).toBe(0);
   expect(record.latitude).toBe(newLocation.coords.latitude);
   expect(record.longitude).toBe(newLocation.coords.longitude);
+
+  const nextLocation = {
+    timestamp: new Date().getUTCMilliseconds() + 1000,
+    mocked: true,
+    coords: {
+      accuracy: 110,
+      latitude: 22.5,
+      longitude: 15.1,
+      heading: 10,
+      speed: 5,
+      altitude: 400,
+      altitudeAccuracy: 0,
+    },
+  };
+
+  // Trigger a location update.
+  await renderer.act(() => {
+    // @ts-ignore
+    // this is a mock method
+    Location._emitLocation(nextLocation);
+  });
+
+  // change me.
+  expect(record.distance).toBe(300);
+  expect(record.latitude).toBe(nextLocation.coords.latitude);
+  expect(record.longitude).toBe(nextLocation.coords.longitude);
 
   // Now check for record in realtime db.
   tree.unmount();

--- a/setup.ts
+++ b/setup.ts
@@ -80,10 +80,13 @@ jest.mock('./src/lib/strava', () => {
 
 jest.mock('expo-location', () => {
   const mod = jest.requireActual('expo-location');
-  const _callbacks: any[] = [];
+  let _callbacks: any[] = [];
 
   return {
     ...mod,
+    clearAll: () => {
+      _callbacks = [];
+    },
     _emitLocation: (loc: any) => {
       return Promise.all([_callbacks.map(cb => cb(loc))]);
     },

--- a/setupHooks.ts
+++ b/setupHooks.ts
@@ -1,5 +1,6 @@
 import {SECURE_STORE_CURRENT_USER_KEY} from './src/constants';
 import * as SecureStore from 'expo-secure-store';
+import * as Location from 'expo-location';
 import {authorize} from './src/lib/strava';
 
 export async function writeStravaToken() {
@@ -16,6 +17,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
   // @ts-ignore: TODO fix mock type.
+  await Location.clearAll();
+  // @ts-ignore: TODO fix mock type.
   await SecureStore.clearAll();
-  jest.resetAllMocks();
+  jest.clearAllMocks();
 });

--- a/setupHooks.ts
+++ b/setupHooks.ts
@@ -17,5 +17,5 @@ beforeEach(async () => {
 afterEach(async () => {
   // @ts-ignore: TODO fix mock type.
   await SecureStore.clearAll();
-  jest.clearAllMocks();
+  jest.resetAllMocks();
 });

--- a/src/components/WidgetGrid/index.tsx
+++ b/src/components/WidgetGrid/index.tsx
@@ -4,7 +4,7 @@ import withObservables from '@nozbe/with-observables';
 import {SimpleMetric} from '../SimpleMetric';
 import {REALTIME_DATA_ID} from '../../constants';
 import {db, RealtimeDataModel} from '../../database';
-import { metersToKilometers } from '../../lib/distance';
+import {metersToKilometers} from '../../lib/distance';
 
 const GUTTER = 1;
 

--- a/src/components/WidgetGrid/index.tsx
+++ b/src/components/WidgetGrid/index.tsx
@@ -4,6 +4,7 @@ import withObservables from '@nozbe/with-observables';
 import {SimpleMetric} from '../SimpleMetric';
 import {REALTIME_DATA_ID} from '../../constants';
 import {db, RealtimeDataModel} from '../../database';
+import { metersToKilometers } from '../../lib/distance';
 
 const GUTTER = 1;
 
@@ -40,7 +41,7 @@ function WidgetGrid({realtimeData}: Props) {
         <Col gx={GUTTER}>
           <SimpleMetric
             title={'Distance '}
-            data={realtimeData.distance}
+            data={metersToKilometers(realtimeData.distance)} // Maybe this converstion should be so
             icon={'map-marker-distance'}
           />
         </Col>

--- a/src/lib/distance.test.ts
+++ b/src/lib/distance.test.ts
@@ -1,0 +1,34 @@
+// distanceCalculator.test.ts
+
+import { LatLngAlt, haversineDistanceWithAltitude, toRadians } from './distance';
+
+describe('haversineDistanceWithAltitude', () => {
+  it('returns 0 for the same point', () => {
+    const point: LatLngAlt = { lat: 40.7128, lng: -74.0060, alt: 10 };
+    expect(haversineDistanceWithAltitude(point, point)).toBe(0);
+  });
+
+  it('returns the correct distance for two different points without altitude difference', () => {
+    const point1: LatLngAlt = { lat: 41.38811, lng: 2.19618, alt: 7 };
+    const point2: LatLngAlt = { lat: 41.39556, lng: 2.20608, alt: 7 };
+    const distance = haversineDistanceWithAltitude(point1, point2);
+    expect(distance).toBeCloseTo(1170.0, 0);
+  });
+
+  it('returns the correct distance for two different points with altitude difference', () => {
+    const point1: LatLngAlt = { lat: 41.4027, lng: 2.1743, alt: 41.00 };
+    const point2: LatLngAlt = { lat: 41.4035, lng: 2.1732, alt: 49.00 };
+    const distance = haversineDistanceWithAltitude(point1, point2);
+    expect(distance).toBeCloseTo(128.0,0); // We want our precision to be with in at least a meter
+  });
+});
+
+describe('toRadians', () => {
+  it('converts degrees to radians', () => {
+    expect(toRadians(0)).toBe(0);
+    expect(toRadians(45)).toBeCloseTo(0.7854, 4);
+    expect(toRadians(90)).toBeCloseTo(1.5708, 4);
+    expect(toRadians(180)).toBe(Math.PI);
+    expect(toRadians(360)).toBe(2 * Math.PI);
+  });
+});

--- a/src/lib/distance.test.ts
+++ b/src/lib/distance.test.ts
@@ -1,25 +1,30 @@
 // distanceCalculator.test.ts
 
-import { LatLngAlt, haversineDistanceWithAltitude, toRadians } from './distance';
+import {
+  LatLngAlt,
+  accumulateDistance,
+  haversineDistanceWithAltitude,
+  toRadians,
+} from './distance';
 
 describe('haversineDistanceWithAltitude', () => {
   it('returns 0 for the same point', () => {
-    const point: LatLngAlt = { lat: 40.7128, lng: -74.0060, alt: 10 };
+    const point: LatLngAlt = {lat: 40.7128, lng: -74.006, alt: 10};
     expect(haversineDistanceWithAltitude(point, point)).toBe(0);
   });
 
   it('returns the correct distance for two different points without altitude difference', () => {
-    const point1: LatLngAlt = { lat: 41.38811, lng: 2.19618, alt: 7 };
-    const point2: LatLngAlt = { lat: 41.39556, lng: 2.20608, alt: 7 };
+    const point1: LatLngAlt = {lat: 41.38811, lng: 2.19618, alt: 7};
+    const point2: LatLngAlt = {lat: 41.39556, lng: 2.20608, alt: 7};
     const distance = haversineDistanceWithAltitude(point1, point2);
     expect(distance).toBeCloseTo(1170.0, 0);
   });
 
   it('returns the correct distance for two different points with altitude difference', () => {
-    const point1: LatLngAlt = { lat: 41.4027, lng: 2.1743, alt: 41.00 };
-    const point2: LatLngAlt = { lat: 41.4035, lng: 2.1732, alt: 49.00 };
+    const point1: LatLngAlt = {lat: 41.4027, lng: 2.1743, alt: 41.0};
+    const point2: LatLngAlt = {lat: 41.4035, lng: 2.1732, alt: 49.0};
     const distance = haversineDistanceWithAltitude(point1, point2);
-    expect(distance).toBeCloseTo(128.0,0); // We want our precision to be with in at least a meter
+    expect(distance).toBeCloseTo(128.0, 0); // We want our precision to be with in at least a meter
   });
 });
 
@@ -32,3 +37,73 @@ describe('toRadians', () => {
     expect(toRadians(360)).toBe(2 * Math.PI);
   });
 });
+
+// Mocked types
+interface RealtimeDataModel { // This type is not a complete version of the data type, so it annoys the typechecker but still works.
+  latitude: number | null;
+  longitude: number | null;
+  altitude: number | null;
+  distance: number;
+}
+
+interface LocationObject {
+  coords: {
+    latitude: number;
+    longitude: number;
+    altitude: number | null;
+  };
+}
+
+describe('accumulateDistance', () => {
+  it('returns 0 when any of the lastRealTimeRecord properties are null', () => {
+    const lastRealTimeRecord: RealtimeDataModel = {
+      latitude: null,
+      longitude: 10,
+      altitude: 100,
+      distance: 0,
+    };
+    const currentLocation: LocationObject = {
+      coords: {
+        latitude: 20,
+        longitude: 20,
+        altitude: 200,
+      },
+    };
+    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBe(0);
+  });
+
+  it('calculates the correct distance with valid input', () => {
+    const lastRealTimeRecord: RealtimeDataModel = {
+      latitude: 41.4027,
+      longitude: 2.1743,
+      altitude: 41.00,
+      distance: 100,
+    };
+    const currentLocation: LocationObject = {
+      coords: {
+        latitude: 41.4035,
+        longitude: 2.1732,
+        altitude: 49.00,
+      },
+    };
+    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(228.0, 0);
+  });
+
+  it('calculates the correct distance when currentLocation has no altitude', () => {
+    const lastRealTimeRecord: RealtimeDataModel = {
+      latitude: 41.38811,
+      longitude: 2.19618,
+      altitude: 7,
+      distance: 0,
+    };
+    const currentLocation: LocationObject = {
+      coords: {
+        latitude: 41.39556,
+        longitude: 2.20608,
+        altitude: null,
+      },
+    };
+    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(1170, 0);
+  });
+});
+

--- a/src/lib/distance.test.ts
+++ b/src/lib/distance.test.ts
@@ -1,5 +1,6 @@
 // distanceCalculator.test.ts
-
+import {RealtimeDataModel} from '../database';
+import {LocationObject} from 'expo-location';
 import {
   LatLngAlt,
   accumulateDistance,
@@ -38,55 +39,38 @@ describe('toRadians', () => {
   });
 });
 
-// Mocked types
-interface RealtimeDataModel {
-  // This type is not a complete version of the data type, so it annoys the typechecker but still works.
-  latitude: number | null;
-  longitude: number | null;
-  altitude: number | null;
-  distance: number;
-}
-
-interface LocationObject {
-  coords: {
-    latitude: number;
-    longitude: number;
-    altitude: number | null;
-  };
-}
-
 describe('accumulateDistance', () => {
   it('returns 0 when any of the lastRealTimeRecord properties are null', () => {
-    const lastRealTimeRecord: RealtimeDataModel = {
+    const lastRealTimeRecord = {
       latitude: null,
       longitude: 10,
       altitude: 100,
       distance: 0,
-    };
+    } as RealtimeDataModel;
     const currentLocation: LocationObject = {
       coords: {
         latitude: 20,
         longitude: 20,
         altitude: 200,
       },
-    };
+    } as LocationObject;
     expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBe(0);
   });
 
   it('calculates the correct distance with valid input', () => {
-    const lastRealTimeRecord: RealtimeDataModel = {
+    const lastRealTimeRecord = {
       latitude: 41.4027,
       longitude: 2.1743,
       altitude: 41.0,
       distance: 100,
-    };
-    const currentLocation: LocationObject = {
+    } as RealtimeDataModel;
+    const currentLocation = {
       coords: {
         latitude: 41.4035,
         longitude: 2.1732,
         altitude: 49.0,
       },
-    };
+    } as LocationObject;
     expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(
       228.0,
       0,
@@ -94,19 +78,19 @@ describe('accumulateDistance', () => {
   });
 
   it('calculates the correct distance when currentLocation has no altitude', () => {
-    const lastRealTimeRecord: RealtimeDataModel = {
+    const lastRealTimeRecord = {
       latitude: 41.38811,
       longitude: 2.19618,
       altitude: 7,
       distance: 0,
-    };
+    } as RealtimeDataModel;
     const currentLocation: LocationObject = {
       coords: {
         latitude: 41.39556,
         longitude: 2.20608,
         altitude: null,
       },
-    };
+    } as LocationObject;
     expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(
       1170,
       0,

--- a/src/lib/distance.test.ts
+++ b/src/lib/distance.test.ts
@@ -39,7 +39,8 @@ describe('toRadians', () => {
 });
 
 // Mocked types
-interface RealtimeDataModel { // This type is not a complete version of the data type, so it annoys the typechecker but still works.
+interface RealtimeDataModel {
+  // This type is not a complete version of the data type, so it annoys the typechecker but still works.
   latitude: number | null;
   longitude: number | null;
   altitude: number | null;
@@ -76,17 +77,20 @@ describe('accumulateDistance', () => {
     const lastRealTimeRecord: RealtimeDataModel = {
       latitude: 41.4027,
       longitude: 2.1743,
-      altitude: 41.00,
+      altitude: 41.0,
       distance: 100,
     };
     const currentLocation: LocationObject = {
       coords: {
         latitude: 41.4035,
         longitude: 2.1732,
-        altitude: 49.00,
+        altitude: 49.0,
       },
     };
-    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(228.0, 0);
+    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(
+      228.0,
+      0,
+    );
   });
 
   it('calculates the correct distance when currentLocation has no altitude', () => {
@@ -103,7 +107,9 @@ describe('accumulateDistance', () => {
         altitude: null,
       },
     };
-    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(1170, 0);
+    expect(accumulateDistance(lastRealTimeRecord, currentLocation)).toBeCloseTo(
+      1170,
+      0,
+    );
   });
 });
-

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -43,13 +43,13 @@ export function accumulateDistance(
   lastRealTimeRecord: RealtimeDataModel,
   currentLocation: LocationObject,
 ): number {
-    if (
-        lastRealTimeRecord.latitude === null ||
-        lastRealTimeRecord.longitude === null ||
-        lastRealTimeRecord.altitude === null
-      ) {
-        return 0;
-      }
+  if (
+    lastRealTimeRecord.latitude === null ||
+    lastRealTimeRecord.longitude === null ||
+    lastRealTimeRecord.altitude === null
+  ) {
+    return 0;
+  }
   const lastPoint: LatLngAlt = {
     lat: lastRealTimeRecord.latitude,
     lng: lastRealTimeRecord.longitude,
@@ -58,7 +58,9 @@ export function accumulateDistance(
   const nextPoint: LatLngAlt = {
     lat: currentLocation.coords.latitude,
     lng: currentLocation.coords.longitude,
-    alt: currentLocation.coords.altitude ? currentLocation.coords.altitude : lastRealTimeRecord.altitude, // If we don't have a current Alt then assume we are same alt still.
+    alt: currentLocation.coords.altitude
+      ? currentLocation.coords.altitude
+      : lastRealTimeRecord.altitude, // If we don't have a current Alt then assume we are same alt still.
   };
   const segmentDistance = haversineDistanceWithAltitude(lastPoint, nextPoint);
   return lastRealTimeRecord.distance + segmentDistance;

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,0 +1,36 @@
+export type LatLngAlt = {
+  lat: number;
+  lng: number;
+  alt: number;
+};
+
+export function toRadians(degrees: number): number {
+  return degrees * (Math.PI / 180);
+}
+
+// Calc 3D distance between two GPS location points.
+export function haversineDistanceWithAltitude(
+  point1: LatLngAlt,
+  point2: LatLngAlt,
+): number {
+  const R = 6371e3; // Earth's mean radius in meters
+  const lat1Rad = toRadians(point1.lat);
+  const lat2Rad = toRadians(point2.lat);
+  const deltaLat = toRadians(point2.lat - point1.lat);
+  const deltaLng = toRadians(point2.lng - point1.lng);
+
+  const a =
+    Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+    Math.cos(lat1Rad) *
+      Math.cos(lat2Rad) *
+      Math.sin(deltaLng / 2) *
+      Math.sin(deltaLng / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  const surfaceDistance = R * c; // Surface distance in meters
+  const altitudeDifference = point2.alt - point1.alt; // Altitude difference in meters
+
+  return Math.sqrt(
+    surfaceDistance * surfaceDistance + altitudeDifference * altitudeDifference,
+  );
+}

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -38,6 +38,11 @@ export function haversineDistanceWithAltitude(
   );
 }
 
+// Convert meters to kilometers with 1 decimal accuracy
+export function metersToKilometers(m: number) : number{
+  return parseFloat((m/1_000).toFixed(1))
+}
+
 // Calculates the distance between the current location and the last RealTimeRecord location and adds that to the currentDistance.
 export function accumulateDistance(
   lastRealTimeRecord: RealtimeDataModel,

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -39,8 +39,8 @@ export function haversineDistanceWithAltitude(
 }
 
 // Convert meters to kilometers with 1 decimal accuracy
-export function metersToKilometers(m: number) : number{
-  return parseFloat((m/1_000).toFixed(1))
+export function metersToKilometers(m: number): number {
+  return parseFloat((m / 1_000).toFixed(1));
 }
 
 // Calculates the distance between the current location and the last RealTimeRecord location and adds that to the currentDistance.

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,3 +1,6 @@
+import RealtimeDataModel from '../database/model/realtimeDataModel';
+import {LocationObject} from 'expo-location';
+
 export type LatLngAlt = {
   lat: number;
   lng: number;
@@ -33,4 +36,30 @@ export function haversineDistanceWithAltitude(
   return Math.sqrt(
     surfaceDistance * surfaceDistance + altitudeDifference * altitudeDifference,
   );
+}
+
+// Calculates the distance between the current location and the last RealTimeRecord location and adds that to the currentDistance.
+export function accumulateDistance(
+  lastRealTimeRecord: RealtimeDataModel,
+  currentLocation: LocationObject,
+): number {
+    if (
+        lastRealTimeRecord.latitude === null ||
+        lastRealTimeRecord.longitude === null ||
+        lastRealTimeRecord.altitude === null
+      ) {
+        return 0;
+      }
+  const lastPoint: LatLngAlt = {
+    lat: lastRealTimeRecord.latitude,
+    lng: lastRealTimeRecord.longitude,
+    alt: lastRealTimeRecord.altitude,
+  };
+  const nextPoint: LatLngAlt = {
+    lat: currentLocation.coords.latitude,
+    lng: currentLocation.coords.longitude,
+    alt: currentLocation.coords.altitude ? currentLocation.coords.altitude : lastRealTimeRecord.altitude, // If we don't have a current Alt then assume we are same alt still.
+  };
+  const segmentDistance = haversineDistanceWithAltitude(lastPoint, nextPoint);
+  return lastRealTimeRecord.distance + segmentDistance;
 }

--- a/src/lib/realtimeData.ts
+++ b/src/lib/realtimeData.ts
@@ -30,10 +30,9 @@ export async function updateRealTimeRecord(record: RealtimeDataModel) {
   return db.write(async () => {
     return record.update(() => {
       record.instantPower = randomInt();
-      // record.speed = randomInt();
       record.heartRate = randomInt();
       record.cadence = randomInt();
-      record.distance = randomInt();
+
       return record;
     });
   });
@@ -45,7 +44,9 @@ export async function onLocation(
   console.log('New location', location);
 
   const realtimeData = await getOrCreateRealtimeRecord();
+  // TODO: only accumulate distance when there is an active ride.
   const distance = accumulateDistance(realtimeData, location);
+  console.log('accumulated distance: ', distance);
   const {speed, latitude, longitude, heading, altitude} = location.coords;
 
   return db.write(async () => {

--- a/src/lib/realtimeData.ts
+++ b/src/lib/realtimeData.ts
@@ -1,6 +1,7 @@
 import {LocationObject} from 'expo-location';
 import {REALTIME_DATA_ID} from '../constants';
 import {db, RealtimeDataModel} from '../database';
+import {accumulateDistance} from './distance';
 
 export async function getOrCreateRealtimeRecord(): Promise<RealtimeDataModel> {
   const collection = db.get<RealtimeDataModel>('realtime_data');
@@ -44,6 +45,7 @@ export async function onLocation(
   console.log('New location', location);
 
   const realtimeData = await getOrCreateRealtimeRecord();
+  const distance = accumulateDistance(realtimeData, location);
   const {speed, latitude, longitude, heading, altitude} = location.coords;
 
   return db.write(async () => {
@@ -53,6 +55,7 @@ export async function onLocation(
       record.longitude = longitude;
       record.heading = heading;
       record.altitude = altitude;
+      record.distance = distance;
 
       return record;
     });


### PR DESCRIPTION
This PR uses a 3D haversine calculation to determine the distance between the last recorded GPS position and the one we just received. It then takes that distance and adds it to the current value of the "distance" value in realtimeData table and writes it back to the table.

The calculations are all managed in meters and just the display logic converts to km and reduces to a single decimal place. 

**Note:** Currently this distance accumulation is continuous and happens whenever we get an `onLocation` change event, however it should actually only be updating when we have an active ride and should reset back to `0` when the ride is stopped. That will be done in a later PR.