### PR TITLE
Strava token fresh

### DIFF
--- a/setup.ts
+++ b/setup.ts
@@ -37,44 +37,47 @@ jest.mock('expo-auth-session', () => {
   };
 });
 
-jest.mock('./src/lib/strava', () => {
-  const mod = jest.requireActual('./src/lib/strava');
+jest.mock('./src/lib/strava/api', () => {
+  const mod = jest.requireActual('./src/lib/strava/api');
+  const dummyToken = {
+    token_type: 'Bearer',
+    expires_at: new Date().getUTCSeconds() - 21600,
+    expires_in: 21600,
+    refresh_token: 'xyz',
+    access_token: 'abc',
+    athlete: {
+      id: 101,
+      username: null,
+      resource_state: 2,
+      firstname: 'Craig',
+      lastname: 'Mulligan',
+      bio: null,
+      city: '',
+      state: '',
+      country: null,
+      sex: null,
+      premium: false,
+      summit: false,
+      created_at: '2022-03-30T16:36:16Z',
+      updated_at: '2023-03-28T17:43:08Z',
+      badge_type_id: 0,
+      weight: 84.0008,
+      profile_medium:
+        'https://lh3.googleusercontent.com/a/AGNmyxafxyza4C7yewDLpgLWrmXW-Rmrds543HpKSrA_=s96-c',
+      profile:
+        'https://lh3.googleusercontent.com/a/AGNmyxafxyza4C7yewDLpgLWrmXW-Rmrds543HpKSrA_=s96-c',
+      friend: null,
+      follower: null,
+    },
+  };
 
   return {
+    __esModule: true,
     ...mod,
     // ensure we don't call the API in
     // tests accidentally
-    authorize: jest.fn().mockResolvedValue({
-      token_type: 'Bearer',
-      expires_at: 1680054476,
-      expires_in: 21600,
-      refresh_token: 'xyz',
-      access_token: 'abc',
-      athlete: {
-        id: 101,
-        username: null,
-        resource_state: 2,
-        firstname: 'Craig',
-        lastname: 'Mulligan',
-        bio: null,
-        city: '',
-        state: '',
-        country: null,
-        sex: null,
-        premium: false,
-        summit: false,
-        created_at: '2022-03-30T16:36:16Z',
-        updated_at: '2023-03-28T17:43:08Z',
-        badge_type_id: 0,
-        weight: 84.0008,
-        profile_medium:
-          'https://lh3.googleusercontent.com/a/AGNmyxafxyza4C7yewDLpgLWrmXW-Rmrds543HpKSrA_=s96-c',
-        profile:
-          'https://lh3.googleusercontent.com/a/AGNmyxafxyza4C7yewDLpgLWrmXW-Rmrds543HpKSrA_=s96-c',
-        friend: null,
-        follower: null,
-      },
-    }),
+    authorize: jest.fn().mockResolvedValue(dummyToken),
+    refresh: jest.fn().mockResolvedValue(dummyToken),
   };
 });
 

--- a/setup.ts
+++ b/setup.ts
@@ -38,10 +38,9 @@ jest.mock('expo-auth-session', () => {
 });
 
 jest.mock('./src/lib/strava/api', () => {
-  const mod = jest.requireActual('./src/lib/strava/api');
   const dummyToken = {
     token_type: 'Bearer',
-    expires_at: new Date().getUTCSeconds() - 21600,
+    expires_at: Math.round(Date.now() / 1000) + 21600,
     expires_in: 21600,
     refresh_token: 'xyz',
     access_token: 'abc',
@@ -71,13 +70,20 @@ jest.mock('./src/lib/strava/api', () => {
     },
   };
 
+  const {token_type, expires_at, expires_in, refresh_token, access_token} =
+    dummyToken;
+
   return {
-    __esModule: true,
-    ...mod,
     // ensure we don't call the API in
     // tests accidentally
     authorize: jest.fn().mockResolvedValue(dummyToken),
-    refresh: jest.fn().mockResolvedValue(dummyToken),
+    refreshToken: jest.fn().mockResolvedValue({
+      token_type,
+      expires_at,
+      expires_in,
+      refresh_token,
+      access_token,
+    }),
   };
 });
 

--- a/setupHooks.ts
+++ b/setupHooks.ts
@@ -1,13 +1,9 @@
-import {SECURE_STORE_CURRENT_USER_KEY} from './src/constants';
 import * as SecureStore from 'expo-secure-store';
-import {authorize} from './src/lib/strava';
+import * as strava from './src/lib/strava';
 
 export async function writeStravaToken() {
-  const dummyStravaToken = await authorize({code: '123'});
-  await SecureStore.setItemAsync(
-    SECURE_STORE_CURRENT_USER_KEY,
-    JSON.stringify(dummyStravaToken),
-  );
+  const dummyStravaToken = await strava.authorize({code: '123'});
+  await strava.saveToken(dummyStravaToken);
 }
 
 beforeEach(async () => {

--- a/setupHooks.ts
+++ b/setupHooks.ts
@@ -2,7 +2,6 @@ import * as SecureStore from 'expo-secure-store';
 import * as strava from './src/lib/strava';
 import * as Location from 'expo-location';
 
-
 export async function writeStravaToken() {
   const dummyStravaToken = await strava.authorize({code: '123'});
   await strava.saveToken(dummyStravaToken);

--- a/src/components/StravaConnect/index.tsx
+++ b/src/components/StravaConnect/index.tsx
@@ -21,7 +21,7 @@ export default function StravaConnect() {
   const {athlete, authorize, logout} = useStrava();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [request, response, promptAsync] = useAuthRequest(
+  const [_, response, promptAsync] = useAuthRequest(
     {
       clientId: STRAVA_CLIENT_ID,
       scopes: ['activity:write'],
@@ -47,7 +47,6 @@ export default function StravaConnect() {
           setLoading(false);
         });
     } else {
-      setLoading(false);
       // @ts-ignore
       setError(response?.error?.message);
     }
@@ -77,8 +76,8 @@ export default function StravaConnect() {
       <Button
         testID="strava-connect-button"
         mode="contained"
-        disabled={!request || loading}
-        loading={!request || loading}
+        disabled={loading}
+        loading={loading}
         onPress={() => {
           setLoading(true);
           promptAsync();

--- a/src/lib/StravaContext.tsx
+++ b/src/lib/StravaContext.tsx
@@ -6,8 +6,6 @@ import {
   useCallback,
 } from 'react';
 import * as strava from '../lib/strava';
-import * as SecureStore from 'expo-secure-store';
-import {SECURE_STORE_CURRENT_USER_KEY} from '../constants';
 
 type AuthorizeInput = {
   code: string;
@@ -42,16 +40,13 @@ export const StravaProvider = ({
   // see: https://react.dev/reference/react/useCallback#skipping-re-rendering-of-components
   const authorize = useCallback(async (params: AuthorizeInput) => {
     const data = await strava.authorize(params);
-    await SecureStore.setItemAsync(
-      SECURE_STORE_CURRENT_USER_KEY,
-      JSON.stringify(data),
-    );
+    await strava.saveToken(data);
     setAthlete(data.athlete);
   }, []);
 
   const logout = useCallback(async () => {
     // clear storage
-    await SecureStore.deleteItemAsync(SECURE_STORE_CURRENT_USER_KEY);
+    await strava.deleteToken();
     setAthlete(null);
     return;
   }, []);

--- a/src/lib/strava/api.ts
+++ b/src/lib/strava/api.ts
@@ -32,8 +32,20 @@ export type Token = {
   athlete: Athlete;
 };
 
-export async function authorize(params: any): Promise<Token> {
-  const res = await fetch(`${BACKEND}/auth`, {
+// same as token but without Athlete
+export type RefreshToken = {
+  token_type: string;
+  expires_at: number;
+  expires_in: number;
+  refresh_token: string;
+  access_token: string;
+};
+
+async function getToken<T>(
+  type: 'auth' | 'refresh',
+  params: {code: string} | {refreshToken: Token['refresh_token']},
+): Promise<T> {
+  const res = await fetch(`${BACKEND}/${type}`, {
     body: JSON.stringify(params),
     method: 'POST',
     headers: {
@@ -45,35 +57,22 @@ export async function authorize(params: any): Promise<Token> {
   const data = await res.json();
 
   if (!res.ok) {
-    console.log('Authorization fail', data.data);
+    console.log(`token ${type} fail`, data.data);
     throw Error(data.message);
   } else {
-    console.log('Authorization success');
+    console.log(`token ${type} success`);
   }
 
   return data;
 }
 
-export async function refresh(
-  refreshToken: Token['refresh_token'],
-): Promise<Token> {
-  const res = await fetch(`${BACKEND}/refresh`, {
-    body: JSON.stringify({refreshToken}),
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-  });
+export async function authorize({code}: {code: string}): Promise<Token> {
+  return getToken<Token>('auth', {code});
+}
 
-  const data = await res.json();
-
-  if (!res.ok) {
-    console.log('Authorization fail', data.data);
-    throw Error(data.message);
-  } else {
-    console.log('Authorization success');
-  }
-
-  return data;
+export async function refreshToken(
+  t: Token['refresh_token'],
+): Promise<RefreshToken> {
+  // fresh will
+  return getToken<RefreshToken>('refresh', {refreshToken: t});
 }

--- a/src/lib/strava/api.ts
+++ b/src/lib/strava/api.ts
@@ -1,5 +1,4 @@
-import {SECURE_STORE_CURRENT_USER_KEY, BACKEND} from '../constants';
-import * as SecureStore from 'expo-secure-store';
+import {BACKEND} from '../../constants';
 
 export type Athlete = {
   id: number;
@@ -55,16 +54,26 @@ export async function authorize(params: any): Promise<Token> {
   return data;
 }
 
-export async function loadToken(): Promise<Token | null> {
-  // loads the current user from secure storage.
-  // TODO - add a fresh param which will check the expiration date
-  // and refresh the token if it's expired - we will probably only want that
-  // at boot and when uploading the ride file
-  const user = await SecureStore.getItemAsync(SECURE_STORE_CURRENT_USER_KEY);
+export async function refresh(
+  refreshToken: Token['refresh_token'],
+): Promise<Token> {
+  const res = await fetch(`${BACKEND}/refresh`, {
+    body: JSON.stringify({refreshToken}),
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+  });
 
-  if (user) {
-    return JSON.parse(user);
+  const data = await res.json();
+
+  if (!res.ok) {
+    console.log('Authorization fail', data.data);
+    throw Error(data.message);
+  } else {
+    console.log('Authorization success');
   }
 
-  return null;
+  return data;
 }

--- a/src/lib/strava/index.test.ts
+++ b/src/lib/strava/index.test.ts
@@ -1,0 +1,28 @@
+import * as strava from './';
+import {SECURE_STORE_CURRENT_USER_KEY} from '../../constants';
+import * as SecureStore from 'expo-secure-store';
+
+describe('loadToken', () => {
+  it('should NOT refresh if > 5mins of expiry', async () => {
+    await strava.loadToken();
+    expect(strava.refresh).not.toHaveBeenCalled();
+  });
+
+  it('should refresh if < 5mins of expiry', async () => {
+    // I *think because
+    jest.isMockFunction(strava.refresh);
+    const token = await strava.loadToken();
+
+    // make it expire now.
+    // then resave it to the store
+    token!.expires_at = new Date().getUTCSeconds();
+
+    await SecureStore.setItemAsync(
+      SECURE_STORE_CURRENT_USER_KEY,
+      JSON.stringify(token),
+    );
+
+    await strava.loadToken();
+    expect(strava.refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/strava/index.test.ts
+++ b/src/lib/strava/index.test.ts
@@ -1,28 +1,20 @@
 import * as strava from './';
-import {SECURE_STORE_CURRENT_USER_KEY} from '../../constants';
-import * as SecureStore from 'expo-secure-store';
 
 describe('loadToken', () => {
-  it('should NOT refresh if > 5mins of expiry', async () => {
+  it('should NOT refresh if token is valid for > 5 mins', async () => {
     await strava.loadToken();
-    expect(strava.refresh).not.toHaveBeenCalled();
+    expect(strava.refreshToken).not.toHaveBeenCalled();
   });
 
   it('should refresh if < 5mins of expiry', async () => {
-    // I *think because
-    jest.isMockFunction(strava.refresh);
     const token = await strava.loadToken();
-
     // make it expire now.
     // then resave it to the store
     token!.expires_at = new Date().getUTCSeconds();
 
-    await SecureStore.setItemAsync(
-      SECURE_STORE_CURRENT_USER_KEY,
-      JSON.stringify(token),
-    );
+    await strava.saveToken(token as strava.Token);
 
     await strava.loadToken();
-    expect(strava.refresh).toHaveBeenCalledTimes(1);
+    expect(strava.refreshToken).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/strava/index.ts
+++ b/src/lib/strava/index.ts
@@ -1,0 +1,32 @@
+import {SECURE_STORE_CURRENT_USER_KEY} from '../../constants';
+import * as SecureStore from 'expo-secure-store';
+import {authorize, refresh, Athlete, Token} from './api';
+
+// Note loadToken can't be in the same
+// module as .refresh because then mocking doesn't
+// work so we've split it into ./api + index
+async function loadToken(): Promise<Token | null> {
+  const tokenData = await SecureStore.getItemAsync(
+    SECURE_STORE_CURRENT_USER_KEY,
+  );
+
+  if (tokenData) {
+    // ensure its fresh.
+    const token = JSON.parse(tokenData);
+
+    // strava access tokens has a 6hr ttl so we check if they
+    // are within 5 mins of expiry before refreshing.
+    if (token.expires_at + 60 * 5 > new Date().getUTCSeconds()) {
+      console.log('token is expired');
+      return exports.refresh(token.refresh_token);
+    }
+
+    return token;
+  }
+
+  return null;
+}
+
+export {authorize, refresh, loadToken};
+
+export type {Athlete, Token};

--- a/src/lib/strava/index.ts
+++ b/src/lib/strava/index.ts
@@ -1,6 +1,6 @@
 import {SECURE_STORE_CURRENT_USER_KEY} from '../../constants';
 import * as SecureStore from 'expo-secure-store';
-import {authorize, refresh, Athlete, Token} from './api';
+import {authorize, refreshToken, Athlete, Token} from './api';
 
 // Note loadToken can't be in the same
 // module as .refresh because then mocking doesn't
@@ -16,10 +16,31 @@ async function loadToken(): Promise<Token | null> {
 
     // strava access tokens has a 6hr ttl so we check if they
     // are within 5 mins of expiry before refreshing.
-    if (token.expires_at + 60 * 5 > new Date().getUTCSeconds()) {
-      console.log('token is expired');
-      return exports.refresh(token.refresh_token);
+    const now = Math.round(Date.now() / 1000);
+
+    const fiveMinutes = 60 * 5;
+
+    if (now > token.expires_at + fiveMinutes) {
+      console.log(
+        'strava token is expired by ',
+        now - token.expires_at + fiveMinutes,
+      );
+      const newToken = await refreshToken(token.refresh_token);
+
+      const t = {
+        ...newToken,
+        athlete: token.athlete,
+      };
+      await saveToken(t);
+
+      return t;
     }
+
+    console.log(
+      `strava token is still valid for ${
+        token.expires_at + fiveMinutes - now
+      } seconds`,
+    );
 
     return token;
   }
@@ -27,6 +48,17 @@ async function loadToken(): Promise<Token | null> {
   return null;
 }
 
-export {authorize, refresh, loadToken};
+async function saveToken(token: Token) {
+  await SecureStore.setItemAsync(
+    SECURE_STORE_CURRENT_USER_KEY,
+    JSON.stringify(token),
+  );
+}
+
+async function deleteToken() {
+  await SecureStore.deleteItemAsync(SECURE_STORE_CURRENT_USER_KEY);
+}
+
+export {authorize, refreshToken, loadToken, saveToken, deleteToken};
 
 export type {Athlete, Token};


### PR DESCRIPTION
fixes #48. This will ensure when we call `loadToken()` that we always get a token that is valid for atleast 5 mins. 